### PR TITLE
Fix updatepage endpoint to actually update the page

### DIFF
--- a/src/pages/[eventId].tsx
+++ b/src/pages/[eventId].tsx
@@ -49,7 +49,7 @@ export const RenderPage = ({page}: RenderPageProps) => {
 				{description}
 			</p>
 		</div>
-		<CustomComponents items={settings.map((setting) => ({type: setting.component, data: setting.data}))}/>
+		<CustomComponents items={settings.map((setting) => ({type: setting.component, data: setting.data, id: setting.id}))}/>
 	</>
 }
 

--- a/src/pages/[eventId].tsx
+++ b/src/pages/[eventId].tsx
@@ -49,7 +49,7 @@ export const RenderPage = ({page}: RenderPageProps) => {
 				{description}
 			</p>
 		</div>
-		<CustomComponents items={settings.map((setting) => ({type: setting.component, data: setting.data, id: setting.id}))}/>
+		<CustomComponents items={settings.map((setting, i) => ({type: setting.component, data: setting.data, id: i}))}/>
 	</>
 }
 

--- a/src/server/api/routers/page.ts
+++ b/src/server/api/routers/page.ts
@@ -7,8 +7,8 @@ import {
   criticalProcedure,
   publicProcedure,
 } from "~/server/api/trpc";
-import { Db, type prisma } from "~/server/db";
-import { type EventPage, PageSchema, ComponentSettingsSchema, ComponentSettings } from "~/utils/types/page";
+import { type Db } from "~/server/db";
+import { type EventPage, PageSchema, ComponentSettingsSchema, type ComponentSettings } from "~/utils/types/page";
 
 const getPage = async ({input, db}: {input: string, db: Db }) => {
 	const page: EventPage | null = await db.page.findUnique({

--- a/src/server/api/routers/page.ts
+++ b/src/server/api/routers/page.ts
@@ -7,10 +7,10 @@ import {
   criticalProcedure,
   publicProcedure,
 } from "~/server/api/trpc";
-import { type prisma } from "~/server/db";
-import { type EventPage, PageSchema } from "~/utils/types/page";
+import { Db, type prisma } from "~/server/db";
+import { type EventPage, PageSchema, ComponentSettingsSchema, ComponentSettings } from "~/utils/types/page";
 
-const getPage = async ({input, db}: {input: string, db: typeof prisma }) => {
+const getPage = async ({input, db}: {input: string, db: Db }) => {
 	const page: EventPage | null = await db.page.findUnique({
 		where: {
 			url: input
@@ -25,7 +25,7 @@ const getPage = async ({input, db}: {input: string, db: typeof prisma }) => {
 	return page;
 }
 
-const deletePage = async({input, db}: {input: string, db: typeof prisma}) => {
+const deletePage = async({input, db}: {input: string, db: Db}) => {
 	await db.page.delete({
 		where: {
 			id: input
@@ -33,7 +33,7 @@ const deletePage = async({input, db}: {input: string, db: typeof prisma}) => {
 	});
 }
 
-const createPage = async ({input, db}: {input: EventPage, db: typeof prisma}) => {
+const createPage = async ({input, db}: {input: EventPage, db: Db}) => {
 	const page: EventPage = await db.page.create({
 		data: {
 			id: input.id || undefined,
@@ -99,9 +99,68 @@ export const pageRouter = createTRPCRouter({
 	updatePage: criticalProcedure
 		.input(PageSchema)
 		.mutation(async ({ctx, input}) => {
-			await deletePage({input: input.id, db: ctx.prisma});
-			const page: EventPage = await createPage({input: input, db: ctx.prisma});
-			
+			const page: EventPage = await ctx.prisma.page.update({
+				data: {
+					title: input.title,
+					description: input.description,
+					url: input.url,
+				},
+				include: {
+					settings: {include: {data: true}}
+				},
+				where: {
+					id: input.id
+				}
+			}) as EventPage;
+
 			return page;
-		})
+		}),
+	createSetting: criticalProcedure
+		.input(ComponentSettingsSchema)
+		.mutation(async ({ctx, input}) => {
+			const setting: ComponentSettings = await ctx.prisma.componentSettings.create({
+				data: {
+					data: {create: input.data},
+					component: input.component,
+					page: {
+						connect: {id: input.pageId}
+					}
+				},
+				include: {
+					data: true
+				}
+			}) as ComponentSettings;
+
+			return setting;
+		}),
+	updateSetting: criticalProcedure
+		.input(ComponentSettingsSchema)
+		.mutation(async ({ctx, input}) => {
+			const setting: ComponentSettings = await ctx.prisma.componentSettings.update({
+				data: {
+					data: {update: input.data},
+					component: input.component,
+					page: {
+						connect: {id: input.pageId}
+					}
+				},
+				include: {
+					data: true
+				},
+				where: {
+					id: input.id
+				}
+			}) as ComponentSettings
+
+			return setting;
+		}),
+	deleteSetting: criticalProcedure
+		.input(z.number())
+		.mutation(async ({ctx, input}) => {
+			await ctx.prisma.componentSettings.delete({
+				where: {
+					id: input
+				}
+			});
+		}),
 });

--- a/src/test/util.tsx
+++ b/src/test/util.tsx
@@ -31,7 +31,7 @@ export const categories: TimelineCategory[] = [
 	{
 		id: 1,
 		name: "Book of Mormon",
-		pageId: "book-of-mormon",
+		pageId: "0",
 		color: colors["Book of Mormon"],
 		items: [
 			{
@@ -111,7 +111,7 @@ export const categories: TimelineCategory[] = [
 	{
 		id: 2,
 		name: "Book of Mormon Translation",
-		pageId: "book-of-mormon-translation",
+		pageId: "1",
 		color: colors["Book of Mormon Translation"],
 		items: [
 			{

--- a/src/utils/components/auth/login-form.tsx
+++ b/src/utils/components/auth/login-form.tsx
@@ -1,7 +1,6 @@
 import Button from '~/utils/components/base/button';
 import Input from '~/utils/components/base/input';
 import Label from '~/utils/components/base/label';
-import { Hyperlink } from '../base/hyperlink';
 import { useState } from 'react';
 import { type Login } from '~/utils/types/auth';
 type LoginFormComponentProps = {

--- a/src/utils/components/base/addremove.tsx
+++ b/src/utils/components/base/addremove.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
-import Editable from '~/utils/components/edit/editable';
+import Editable, { type EditableComponent, type EditableComponentProps } from '~/utils/components/edit/editable';
 import {type ButtonIcon} from '~/utils/components/edit/editable';
 import Button from '~/utils/components/base/button';
 import {DeleteIcon} from '~/utils/components/icons/icons';
-type AddRemoveProps = {
-	items: React.ReactNode[],
-	onDelete: (i: number) => void,
-	onAdd: () => void
+import { type PolymorphicCustomProps } from '~/utils/types/polymorphic';
+import { DirtyComponent } from '../edit/dirty-component';
+
+export type RenderableComponent<T> = {
+	component: React.ComponentType<T>,
+	props: T
 }
-const AddRemove = ({items, onDelete, onAdd}: AddRemoveProps) => {
+type AddRemoveProps<T> = {
+	items: RenderableComponent<T>[],
+	onAdd: () => void,
+	onDelete: (index: number) => void
+}
+const AddRemove = ({items, onAdd, onDelete}: AddRemoveProps<object>) => {
 	return <>
 		{items.map((item, i) => {
-			const icons: ButtonIcon[] = [
-				{
-					icon: DeleteIcon,
-					handler: () => onDelete(i)
-				}
-			]
-			return <Editable icons={icons} key={i} editable="false">{item}</Editable>
+			return <AddRemoveItem key={i} component={item.component} onDelete={() => onDelete(i)} {...item.props}/>
 		})}
 		<div>
 			<Button mode="secondary" className="my-1" onClick={onAdd}>
@@ -25,6 +26,44 @@ const AddRemove = ({items, onDelete, onAdd}: AddRemoveProps) => {
 			</Button>
 		</div>
 	</>
+}
+
+type AddRemoveEditableProps<T> = {
+	isDirty?: false,
+} | {
+	isDirty: true,
+	isNewItem: (item: T) => boolean
+}
+export const AddRemoveEditable = <K,>({items, onAdd, ...rest}: Omit<AddRemoveProps<EditableComponentProps<K>>, 'onDelete'> & AddRemoveEditableProps<K>) => {
+	return <>
+		{items.map((item, i) => {
+			const props: AddRemoveItemProps<EditableComponent<K>> = {...item.props, component: item.component};
+			if (rest.isDirty) {
+				const isNew = rest.isNewItem(item.props.data);
+				return <DirtyComponent key={i} as={AddRemoveItem} {...props} dirty={isNew} overrideDelete={isNew} showCancel={!isNew}/>;
+			}
+			return <AddRemoveItem key={i} {...props}/>
+		})}
+		<div>
+			<Button mode="secondary" className="my-1" onClick={onAdd}>
+				+
+			</Button>
+		</div>
+	</>
+}
+type Props = {
+	onDelete: () => void
+}
+type AddRemoveItemProps<T extends React.ElementType> = PolymorphicCustomProps<T, Props, {component?: T}>
+const AddRemoveItem = <T extends React.ElementType>({component, onDelete, ...rest}: AddRemoveItemProps<T>) => {
+	const Component = component || 'span';
+	const icons: ButtonIcon[] = [
+		{
+			icon: DeleteIcon,
+			handler: onDelete
+		}
+	];
+	return <Editable icons={icons} editable="false"><Component {...rest}/></Editable>
 }
 
 export default AddRemove;

--- a/src/utils/components/base/addremove.tsx
+++ b/src/utils/components/base/addremove.tsx
@@ -8,7 +8,8 @@ import { DirtyComponent } from '../edit/dirty-component';
 
 export type RenderableComponent<T> = {
 	component: React.ComponentType<T>,
-	props: T
+	props: T,
+	id: string
 }
 type AddRemoveProps<T> = {
 	items: RenderableComponent<T>[],
@@ -40,7 +41,7 @@ export const AddRemoveEditable = <K,>({items, onAdd, ...rest}: Omit<AddRemovePro
 			const props: AddRemoveItemProps<EditableComponent<K>> = {...item.props, component: item.component};
 			if (rest.isDirty) {
 				const isNew = rest.isNewItem(item.props.data);
-				return <DirtyComponent key={i} as={AddRemoveItem} {...props} dirty={isNew} overrideDelete={isNew} showCancel={!isNew}/>;
+				return <DirtyComponent key={i} as={AddRemoveItem} {...props} dirty={isNew} overrideDelete={isNew} showCancel={!isNew} dataTestId={`dirty-component-${item.id}`}/>;
 			}
 			return <AddRemoveItem key={i} {...props}/>
 		})}

--- a/src/utils/components/base/panel.tsx
+++ b/src/utils/components/base/panel.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 type PanelProps = {
 	className?: string,
-	disabled?: boolean
+	disabled?: boolean,
+	role?: string
 } & React.PropsWithChildren
-const Panel = ({children, className, disabled=false}: PanelProps) => {
+const Panel = ({children, className, disabled=false, role}: PanelProps) => {
 	return <>
-		<div className={`${className || ''} bg-white relative shadow-md rounded-xl p-3 ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2`}>
+		<div className={`${className || ''} bg-white relative shadow-md rounded-xl p-3 ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2`} role={role}>
 			{disabled && <div className="absolute top-0 left-0 h-full w-full opacity-50 bg-red-200 rounded-xl z-10"></div>}
 			{children}
 		</div>

--- a/src/utils/components/base/tab.tsx
+++ b/src/utils/components/base/tab.tsx
@@ -45,7 +45,7 @@ export default function TabControl({items, className}: TabControlProps) {
 								className={classNames(
 									'rounded-xl p-3',
 									item.className,
-									'ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2'
+									'ring-white ring-opacity-60 ring-offset-2 ring-offset-primary focus:outline-none focus:ring-2'
 								)}
 							>
 								{item.component}

--- a/src/utils/components/edit/add-component.tsx
+++ b/src/utils/components/edit/add-component.tsx
@@ -211,20 +211,21 @@ export const useAnnotationLink = () => {
 	return {annotate};
 }
 
-export const CustomComponents = ({items}: {items: CustomComponentType[]}) => {
+export const CustomComponents = ({items, isNew}: {items: CustomComponentType[], isNew: boolean}) => {
 	return <AnnotationLinkProvider>
-		{items.map((item, i) => <CustomComponent key={i} {...item}/>)}
+		{items.map((item, i) => <CustomComponent key={i} {...item} isNew={isNew}/>)}
 	</AnnotationLinkProvider>
 }
 
 type CustomComponentType = (EditableComponentType | DataComponentType) & {id: number};
-export const CustomComponent = (props: CustomComponentType & {id: number}) => {
+export const CustomComponent = (props: CustomComponentType & {isNew: boolean}) => {
 	const Component = components.find(x => x.label == props.type) || components[0];
 	if (props.editable) {
 		const {type: _, editable: _a, id, ...rest} = props;
 		const isNew = id < 0;
 		return <div data-testid={`custom-component-editable-${id}`} role="custom-component-editable">
-			<DirtyComponent as={Component.editable} {...rest} dirty={isNew} overrideDelete={isNew} showCancel={!isNew}></DirtyComponent>
+			{props.isNew ? <Component.editable {...rest}/> : 
+			<DirtyComponent as={Component.editable} {...rest} dirty={isNew} overrideDelete={isNew} showCancel={!isNew}></DirtyComponent>}
 		</div>
 	}
 	

--- a/src/utils/components/edit/add-component.tsx
+++ b/src/utils/components/edit/add-component.tsx
@@ -211,7 +211,7 @@ export const useAnnotationLink = () => {
 	return {annotate};
 }
 
-export const CustomComponents = ({items, isNew}: {items: CustomComponentType[], isNew: boolean}) => {
+export const CustomComponents = ({items, isNew=false}: {items: CustomComponentType[], isNew?: boolean}) => {
 	return <AnnotationLinkProvider>
 		{items.map((item, i) => <CustomComponent key={i} {...item} isNew={isNew}/>)}
 	</AnnotationLinkProvider>

--- a/src/utils/components/edit/add-component.tsx
+++ b/src/utils/components/edit/add-component.tsx
@@ -145,7 +145,7 @@ const components = createComponents(
 	{
 		label: 'Header',
 		editable: (({onDelete, onEdit, data}) => <Editable as={Header} icons={[{icon: DeleteIcon, handler: onDelete}]} 
-			onBlur={(e: React.FocusEvent<HTMLHeadingElement>) => onEdit({content: e.target.innerHTML, properties: null})}>
+			onBlur={(e: React.FocusEvent<HTMLHeadingElement>) => e.target.innerHTML !== data?.content && onEdit({content: e.target.innerHTML, properties: null})}>
 											{data?.content || 'Text'}
 										</Editable>) as React.ComponentType<EditableDataComponent>,
 		component: (({data}) => <Header className="py-2">{data?.content || 'Text'}</Header>) as React.ComponentType<DataComponent>
@@ -153,7 +153,7 @@ const components = createComponents(
 	{
 		label: 'Paragraph',
 		editable: (({onDelete, onEdit, data}) => <Editable as="p" role="paragraph" icons={[{icon: DeleteIcon, handler: onDelete}]} 
-				onBlur={(e: React.FocusEvent<HTMLParagraphElement>) => onEdit({content: e.target.innerHTML, properties: null})}>
+				onBlur={(e: React.FocusEvent<HTMLParagraphElement>) => e.target.innerHTML !== data?.content && onEdit({content: e.target.innerHTML, properties: null})}>
 											{data?.content || 'Text'}
 										</Editable>) as React.ComponentType<EditableDataComponent>,
 		component: (({data}) => <p className="py-2">{data?.content || 'Text'}</p>) as React.ComponentType<DataComponent>

--- a/src/utils/components/edit/add-component.tsx
+++ b/src/utils/components/edit/add-component.tsx
@@ -17,7 +17,7 @@ const Placeholder = ({children}: React.PropsWithChildren) => {
 
 type EditableDataComponent = EditableComponentProps<EditableData> & DataComponent;
 interface DataComponent {
-	data: EditableData | null,
+	data: EditableData,
 	className?: string
 }
 interface Component {
@@ -213,17 +213,18 @@ export const useAnnotationLink = () => {
 
 export const CustomComponents = ({items}: {items: CustomComponentType[]}) => {
 	return <AnnotationLinkProvider>
-		{items.map((item, i) => <CustomComponent key={i} {...item} id={i}/>)}
+		{items.map((item, i) => <CustomComponent key={i} {...item}/>)}
 	</AnnotationLinkProvider>
 }
 
-type CustomComponentType = (EditableComponentType | DataComponentType);
+type CustomComponentType = (EditableComponentType | DataComponentType) & {id: number};
 export const CustomComponent = (props: CustomComponentType & {id: number}) => {
 	const Component = components.find(x => x.label == props.type) || components[0];
 	if (props.editable) {
 		const {type: _, editable: _a, id, ...rest} = props;
+		const isNew = id < 0;
 		return <div data-testid={`custom-component-editable-${id}`} role="custom-component-editable">
-			<DirtyComponent as={Component.editable} {...rest}></DirtyComponent>
+			<DirtyComponent as={Component.editable} {...rest} dirty={isNew} overrideDelete={isNew} showCancel={!isNew}></DirtyComponent>
 		</div>
 	}
 	

--- a/src/utils/components/edit/dirty-component.tsx
+++ b/src/utils/components/edit/dirty-component.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import {type EditableComponent, type EditableComponentProps} from '~/utils/components/edit/editable';
+import {type EditableComponent} from '~/utils/components/edit/editable';
 import { type PolymorphicComponentProps } from '~/utils/types/polymorphic';
 import Button from '~/utils/components/base/button';
 type DirtComponentOtherProps = {
@@ -8,7 +8,7 @@ type DirtComponentOtherProps = {
     overrideEdit?: boolean,
     dirty?: boolean
 }
-type DirtyComponentProps<T,> = PolymorphicComponentProps<EditableComponent<T>, EditableComponentProps<T>> & DirtComponentOtherProps;
+type DirtyComponentProps<K, T extends EditableComponent<K>> = PolymorphicComponentProps<T, DirtComponentOtherProps>;
 type DirtyState<T> = {
     state: false
 } | ({
@@ -22,9 +22,9 @@ type DirtyType<T> = {
     type: "delete"
 }
 
-export const DirtyComponent = <T,>({as, onDelete: onDeleteProps, onEdit: onEditProps, data, dirty=false, overrideDelete, overrideEdit, showCancel=true}: DirtyComponentProps<T>) => {
-    const [dirtyState, setDirtyState] = useState<DirtyState<T>>(dirty ? {state: true, type: 'edit', data} : {state: false});
-    const [currData, setCurrData] = useState<T>(data);
+export const DirtyComponent = <K, T extends EditableComponent<K>>({as, onDelete: onDeleteProps, onEdit: onEditProps, data, dirty=false, overrideDelete, overrideEdit, showCancel=true, ...rest}: DirtyComponentProps<K,T>) => {
+    const [dirtyState, setDirtyState] = useState<DirtyState<K>>(dirty ? {state: true, type: 'edit', data} : {state: false});
+    const [currData, setCurrData] = useState<K>(data);
     
     useEffect(() => setCurrData(data), [data]);
 
@@ -36,7 +36,7 @@ export const DirtyComponent = <T,>({as, onDelete: onDeleteProps, onEdit: onEditP
         }
     }
 
-    const onEdit = (data: T) => {
+    const onEdit = (data: K) => {
         if (overrideEdit) {
             onEditProps(data);
         } else { 
@@ -60,13 +60,10 @@ export const DirtyComponent = <T,>({as, onDelete: onDeleteProps, onEdit: onEditP
         setDirtyState({state: false});
     }
 
-    if (!as) {
-        return <div></div>
-    }
-    const Component = as;
+    const Component = as || 'span';
     return <div className="relative">
         {dirtyState.state && dirtyState.type == 'delete' && <div className="absolute top-0 left-0 h-full w-full opacity-50 bg-red-200 rounded-xl z-10"></div>}
-        <Component onDelete={onDelete} onEdit={onEdit} data={currData}/>
+        <Component onDelete={onDelete} onEdit={onEdit} data={currData} {...rest}/>
         {dirtyState.state && <div className="my-1 text-right mx-4 z-10 relative">
             {showCancel && <Button className="mx-1" mode="secondary" onClick={onCancel}>Cancel</Button>}
             <Button mode="primary" onClick={onSave}>Save</Button>

--- a/src/utils/components/edit/dirty-component.tsx
+++ b/src/utils/components/edit/dirty-component.tsx
@@ -1,0 +1,61 @@
+import { useReducer, useState } from 'react';
+import {EditableComponent, EditableComponentProps} from '~/utils/components/edit/editable';
+import { PolymorphicComponentProps } from '~/utils/types/polymorphic';
+import Button from '~/utils/components/base/button';
+type DirtyComponentProps<T,> = PolymorphicComponentProps<EditableComponent<T>, EditableComponentProps<T>>;
+type DirtyState<T> = {
+    state: false
+} | ({
+    state: true
+} & DirtyType<T>);
+
+type DirtyType<T> = {
+    type: "edit",
+    data: T
+} | {
+    type: "delete"
+}
+
+export const DirtyComponent = <T,>({as, onDelete: onDeleteProps, onEdit: onEditProps, data}: DirtyComponentProps<T>) => {
+    const [dirtyState, setDirtyState] = useState<DirtyState<T>>({state: false});
+    const [currData, setCurrData] = useState<T | null>(data);
+    const isNew = false;
+    const disabled = false;
+    const showCancel = true; //item.id > 0
+
+    const onDelete = () => {
+        setDirtyState({state: true, type: "delete"});
+    }
+
+    const onEdit = (data: T) => {
+        setDirtyState({state: true, type: "edit", data});
+        setCurrData(data);
+    }
+
+    const onSave = () => {
+        if (!dirtyState.state) return;
+        if (dirtyState.type == "edit") {
+            onEditProps(dirtyState.data);
+        } else {
+            onDeleteProps();
+        }
+        setDirtyState({state: false});
+    }
+
+    const onCancel = () => {
+        setCurrData(data);
+        setDirtyState({state: false});
+    }
+
+    if (!as) {
+        return <div></div>
+    }
+    const Component = as;
+    return <div className="relative">
+        <Component onDelete={onDelete} onEdit={onEdit} data={currData}/>
+        {!isNew && (dirtyState.state || disabled) && <div className="my-1 text-right mx-4 z-20 relative">
+            {showCancel && <Button className="mx-1" mode="secondary" onClick={onCancel}>Cancel</Button>}
+            <Button mode="primary" onClick={onSave}>Save</Button>
+        </div>}
+    </div>
+}

--- a/src/utils/components/edit/dirty-component.tsx
+++ b/src/utils/components/edit/dirty-component.tsx
@@ -1,6 +1,6 @@
-import { useReducer, useState } from 'react';
-import {EditableComponent, EditableComponentProps} from '~/utils/components/edit/editable';
-import { PolymorphicComponentProps } from '~/utils/types/polymorphic';
+import { useEffect, useState } from 'react';
+import {type EditableComponent, type EditableComponentProps} from '~/utils/components/edit/editable';
+import { type PolymorphicComponentProps } from '~/utils/types/polymorphic';
 import Button from '~/utils/components/base/button';
 type DirtyComponentProps<T,> = PolymorphicComponentProps<EditableComponent<T>, EditableComponentProps<T>>;
 type DirtyState<T> = {
@@ -21,7 +21,9 @@ export const DirtyComponent = <T,>({as, onDelete: onDeleteProps, onEdit: onEditP
     const [currData, setCurrData] = useState<T | null>(data);
     const isNew = false;
     const disabled = false;
-    const showCancel = true; //item.id > 0
+    const showCancel = true;
+
+    useEffect(() => setCurrData(data), [data]);
 
     const onDelete = () => {
         setDirtyState({state: true, type: "delete"});
@@ -52,6 +54,7 @@ export const DirtyComponent = <T,>({as, onDelete: onDeleteProps, onEdit: onEditP
     }
     const Component = as;
     return <div className="relative">
+        {dirtyState.state && dirtyState.type == 'delete' && <div className="absolute top-0 left-0 h-full w-full opacity-50 bg-red-200 rounded-xl z-10"></div>}
         <Component onDelete={onDelete} onEdit={onEdit} data={currData}/>
         {!isNew && (dirtyState.state || disabled) && <div className="my-1 text-right mx-4 z-20 relative">
             {showCancel && <Button className="mx-1" mode="secondary" onClick={onCancel}>Cancel</Button>}

--- a/src/utils/components/edit/dirty-component.tsx
+++ b/src/utils/components/edit/dirty-component.tsx
@@ -6,7 +6,8 @@ type DirtComponentOtherProps = {
     showCancel?: boolean,
     overrideDelete?: boolean,
     overrideEdit?: boolean,
-    dirty?: boolean
+    dirty?: boolean,
+    dataTestId?: string
 }
 type DirtyComponentProps<K, T extends EditableComponent<K>> = PolymorphicComponentProps<T, DirtComponentOtherProps>;
 type DirtyState<T> = {
@@ -22,7 +23,7 @@ type DirtyType<T> = {
     type: "delete"
 }
 
-export const DirtyComponent = <K, T extends EditableComponent<K>>({as, onDelete: onDeleteProps, onEdit: onEditProps, data, dirty=false, overrideDelete, overrideEdit, showCancel=true, ...rest}: DirtyComponentProps<K,T>) => {
+export const DirtyComponent = <K, T extends EditableComponent<K>>({as, onDelete: onDeleteProps, onEdit: onEditProps, data, dirty=false, overrideDelete, overrideEdit, showCancel=true, dataTestId, ...rest}: DirtyComponentProps<K,T>) => {
     const [dirtyState, setDirtyState] = useState<DirtyState<K>>(dirty ? {state: true, type: 'edit', data} : {state: false});
     const [currData, setCurrData] = useState<K>(data);
     
@@ -61,8 +62,8 @@ export const DirtyComponent = <K, T extends EditableComponent<K>>({as, onDelete:
     }
 
     const Component = as || 'span';
-    return <div className="relative">
-        {dirtyState.state && dirtyState.type == 'delete' && <div className="absolute top-0 left-0 h-full w-full opacity-50 bg-red-200 rounded-xl z-10"></div>}
+    return <div className="relative" data-testid={dataTestId}>
+        {dirtyState.state && dirtyState.type == 'delete' && <div className="absolute top-0 left-0 h-full w-full opacity-50 bg-red-200 rounded-xl z-10" data-testid="dirty-state-delete"></div>}
         <Component onDelete={onDelete} onEdit={onEdit} data={currData} {...rest}/>
         {dirtyState.state && <div className="my-1 text-right mx-4 z-10 relative">
             {showCancel && <Button className="mx-1" mode="secondary" onClick={onCancel}>Cancel</Button>}

--- a/src/utils/components/edit/edit-pages.tsx
+++ b/src/utils/components/edit/edit-pages.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {useEffect, useState} from 'react';
 import {type DropdownItem} from '~/utils/components/base/dropdown';
 import Button from '~/utils/components/base/button';
-import {useEventPagesMutation, useGetPages} from '~/utils/services/EventPageService';
+import {useComponentSettingsMutation, useEventPagesMutation, useGetPages} from '~/utils/services/EventPageService';
 import {type EventPage, type ComponentSettings, type EditableData} from '~/utils/types/page';
 import Input from '~/utils/components/base/input';
 import EditItemsButtons from '~/utils/components/edit/edit-items-buttons';
@@ -19,6 +19,7 @@ export type EditPagesProps = {
 export const EditPages = ({setId}: EditPagesProps) => {
 	const [currPage, setCurrPage] = useState<EventPage>();
 	const {create, update, deletem} = useEventPagesMutation();
+	const {create: createSetting, update: updateSetting, deletem: deleteSetting} = useComponentSettingsMutation();
 	const query = useGetPages();
 
 	let pages: EventPage[] | null = null;
@@ -81,39 +82,67 @@ export const EditPages = ({setId}: EditPagesProps) => {
 	return <>
 		<div>
 			<EditItemsButtons items={items} value={currPage?.id} onChange={onChange}
-				onAdd={onAddPage} onSave={onSave} onDelete={onDelete} onClear={onClear}/>
-			{currPage && <>
-			<div className="py-1">
-				<Input include={Label} label="Url" value={currPage.url} onChange={onNameChange} className="ml-1 my-1"/>
-				<Button as={Link} href={`/${currPage.url}`} className="ml-1">Go</Button>
-			</div>
-			<EditablePage page={currPage} setPage={setCurrPage} />
-			</>}
+				onAdd={onAddPage} onSave={onSave} onDelete={onDelete} onClear={onClear}>
+				{({isNew}) => <>
+						{currPage && <>
+						<div className="py-1">
+							<Input include={Label} label="Url" value={currPage.url} onChange={onNameChange} className="ml-1 my-1"/>
+							<Button as={Link} href={`/${currPage.url}`} className="ml-1">Go</Button>
+						</div>
+						<EditablePage page={currPage} setPage={setCurrPage} isNew={isNew} 
+							createSetting={createSetting.mutate} updateSetting={updateSetting.mutate} deleteSetting={deleteSetting.mutate}/>
+						</>}
+					</>}
+			</EditItemsButtons>
+			
 		</div>	
 	</>
 }
 
 
-
-const EditablePage = ({page, setPage}: {page: EventPage, setPage: (page: EventPage) => void}) => {
+type EditablePageProps = {
+	page: EventPage, 
+	setPage: (page: EventPage) => void, 
+	isNew: boolean,
+	createSetting: (setting: ComponentSettings) => void,
+	updateSetting: (setting: ComponentSettings) => void,
+	deleteSetting: (id: number) => void,
+}
+const EditablePage = ({page, setPage, isNew, createSetting, updateSetting, deleteSetting}: EditablePageProps) => {
 	const editSettings = (f: (settings: ComponentSettings[]) => void) => {
 		const copy: EventPage = {...page};
 		const settings = copy.settings.slice();
 		f(settings);
 		copy.settings = settings;
 		setPage(copy);
+
+		return copy;
 	}
 
 	const onAdd = (component: ComponentType) => {
-		editSettings(components => components.push({component: component, data: {content: "custom", properties: null}, id: -1, pageId: ""}));
+		editSettings(components => components.push({component: component, data: {content: "custom", properties: null}, id: -1, pageId: page.id}));
 	}
 
 	const onEdit = (data: EditableData, i: number) => {
-		editSettings(components => (components[i] || {data: null}).data = data);
+		const page = editSettings(components => (components[i] || {data: null}).data = data);
+		const setting = page.settings[i];
+		if (!setting) {
+			throw new Error("Cannot update setting");
+		}
+		if (setting.id >= 0) {
+			!isNew && updateSetting(setting);
+		} else {
+			!isNew && createSetting(setting);
+		}
 	}
 
 	const deleteComponent = (index: number) => {
-		editSettings(components => components.splice(index, 1))
+		editSettings(components => components.splice(index, 1));
+		const setting = page.settings[index];
+		if (!setting) {
+			throw new Error("Cannot delete setting");
+		}
+		!isNew && setting.id >= 0 && deleteSetting(setting.id);
 	}
 	return <>
 			<Editable as="h1" className="mx-auto text-3xl font-bold my-5 text-bom" onBlur={(e: React.FocusEvent<HTMLHeadingElement>) => setPage({...page, title: e.target.innerHTML})}>
@@ -122,7 +151,7 @@ const EditablePage = ({page, setPage}: {page: EventPage, setPage: (page: EventPa
 			<Editable as="p" onBlur={(e: React.FocusEvent<HTMLParagraphElement>) => setPage({...page, description: e.target.innerHTML})}>
 				{page.description}
 			</Editable>
-			<CustomComponents items={page.settings.map((editable: ComponentSettings, i: number) => ({editable: true, id: editable.id, type: editable.component, onDelete: () => deleteComponent(i), onEdit: (data: EditableData) => onEdit(data, i), data: editable.data}))}/>
+			<CustomComponents isNew={isNew} items={page.settings.map((editable: ComponentSettings, i: number) => ({editable: true, id: editable.id, type: editable.component, onDelete: () => deleteComponent(i), onEdit: (data: EditableData) => onEdit(data, i), data: editable.data}))}/>
 			<AddComponent onAdd={onAdd}/>
 	</>
 }

--- a/src/utils/components/edit/edit-pages.tsx
+++ b/src/utils/components/edit/edit-pages.tsx
@@ -122,7 +122,7 @@ const EditablePage = ({page, setPage}: {page: EventPage, setPage: (page: EventPa
 			<Editable as="p" onBlur={(e: React.FocusEvent<HTMLParagraphElement>) => setPage({...page, description: e.target.innerHTML})}>
 				{page.description}
 			</Editable>
-			<CustomComponents items={page.settings.map((editable: ComponentSettings, i: number) => ({editable: true, type: editable.component, onDelete: () => deleteComponent(i), onEdit: (data: EditableData) => onEdit(data, i), data: editable.data}))}/>
+			<CustomComponents items={page.settings.map((editable: ComponentSettings, i: number) => ({editable: true, id: editable.id, type: editable.component, onDelete: () => deleteComponent(i), onEdit: (data: EditableData) => onEdit(data, i), data: editable.data}))}/>
 			<AddComponent onAdd={onAdd}/>
 	</>
 }

--- a/src/utils/components/edit/edit-timeline-items.tsx
+++ b/src/utils/components/edit/edit-timeline-items.tsx
@@ -1,23 +1,22 @@
 import {useEffect, useState} from 'react';
 import Dropdown from '~/utils/components/base/dropdown';
 import {type ItemAction, type DropdownItem} from '~/utils/components/base/dropdown';
-import Button from '~/utils/components/base/button';
 import {useGetPages} from '~/utils/services/EventPageService';
 import {useCategoryMutations, useGetCategories, useTimelineMutations} from '~/utils/services/TimelineService';
 import {type RestorationTimelineItem, type TimelineCategory} from '~/utils/types/timeline';
 import {useChangeProperty, groupByDistinct} from '~/utils/utils';
 import Panel from '~/utils/components/base/panel';
-import AddRemove from '~/utils/components/base/addremove';
+import AddRemove, { AddRemoveEditable } from '~/utils/components/base/addremove';
 import Input from '~/utils/components/base/input';
 import EditItemsButtons from '~/utils/components/edit/edit-items-buttons';
 import Label from '~/utils/components/base/label';
 import ColorPicker from '~/utils/components/base/color-picker';
 import {DateRangePicker} from '~/utils/components/base/calendar/date-picker';
 import { RemoveField } from '../base/remove-field';
+import { type EditableComponentProps } from './editable';
 
 export const EditTimelineItems = () => {
 	const [category, setCategory] = useState<TimelineCategory>();
-	const [markedForDelete, setMarkedForDelete] = useState<Record<number, boolean>>({});
 	const changeProperty = useChangeProperty<TimelineCategory>(setCategory);
 	const {update, create, deletem} = useCategoryMutations();
 	const {update: updateItem, create: createItem, deletem: deleteItem} = useTimelineMutations();
@@ -97,15 +96,10 @@ export const EditTimelineItems = () => {
 		const item = category.items[i];
 		if (!item) return;
 
-		if (item.id > 0) {
-			const markCopy = {...markedForDelete};
-			markCopy[item.id] = true;
-			setMarkedForDelete(markCopy);
-		} else {
-			const copy = category.items.slice();
-			copy.splice(i, 1);
-			changeProperty(category, "items", copy);
-		}
+		const copy = category.items.slice();
+		copy.splice(i, 1);
+		item.id > 0 && deleteItem.mutate(item.id);
+		changeProperty(category, "items", copy);
 	}
 
 	const onItemAdd = () => {
@@ -126,22 +120,9 @@ export const EditTimelineItems = () => {
 	const saveItem = (item: RestorationTimelineItem, i: number) => {
 		if (!category) return;
 		const copy = category.items.slice();
-		if (markedForDelete[item.id]) {
-			copy.splice(i, 1);
-			item.id > 0 && deleteItem.mutate(item.id);
-			
-			deleteMarkedForDelete(item.id);
-		} else {
-			copy[i] = item;
-			item.id < 0 ? createItem.mutate(item) : updateItem.mutate(item);
-		}
+		copy[i] = item;
+		item.id < 0 ? createItem.mutate(item) : updateItem.mutate(item);
 		changeProperty(category, "items", copy);
-	}
-
-	const deleteMarkedForDelete = (id: number) => {
-		const markCopy = {...markedForDelete};
-		markCopy[id] = false;
-		setMarkedForDelete(markCopy);
 	}
 	
 	return <>
@@ -161,11 +142,12 @@ export const EditTimelineItems = () => {
 							<ColorPicker value={category.color} onChange={(color) => changeProperty(category, 'color', color)}/>
 						</Label>
 					</div>
-					<AddRemove items={category.items.map((item, i) => 
-						<EditRestorationItem key={i} item={item} onSave={(item: RestorationTimelineItem) => saveItem(item, i)} 
-							disabled={markedForDelete[item.id]} cancelDisabled={deleteMarkedForDelete} isNew={isNew}
-						/>)}
-						onAdd={onItemAdd} onDelete={onItemDelete}
+					<AddRemoveEditable items={category.items.map((item, i) => ({component: EditRestorationItem, props: {
+							data: item, 
+							onEdit: (item: RestorationTimelineItem) => saveItem(item, i),
+							onDelete: () => onItemDelete(i)
+						}}))}
+						onAdd={onItemAdd} isDirty={!isNew} isNewItem={item => item.id < 0}
 					/>
 					</>}
 				</>)}
@@ -174,87 +156,51 @@ export const EditTimelineItems = () => {
 	</>
 }
 
-type EditRestorationItemProps = {
-	item: RestorationTimelineItem,
-	onSave: (item: RestorationTimelineItem) => void,
-	disabled?: boolean,
-	cancelDisabled: (id: number) => void,
-	isNew: boolean
-}
-const EditRestorationItem = ({item: propItem, disabled=false, onSave: onSaveProp, cancelDisabled, isNew}: EditRestorationItemProps) => {
-	const [item, setItem] = useState<RestorationTimelineItem>(propItem);
-	const [isDirty, setIsDirty] = useState(false);
-	const changePropertyItem = useChangeProperty<RestorationTimelineItem>((item: RestorationTimelineItem) => {
-		setIsDirty(true);
-		setItem(item);
-		if (isNew) {
-			onSaveProp(item);
-		}
-	});
-	useEffect(() => {
-		if (propItem.id < 0) {
-			setIsDirty(true);
-		}
-		setItem(propItem);
-		
-	}, [propItem])
+type EditRestorationItemProps = EditableComponentProps<RestorationTimelineItem>
+const EditRestorationItem = ({data: propItem, onEdit: onSaveProp}: EditRestorationItemProps) => {
+	const changePropertyItem = useChangeProperty<RestorationTimelineItem>(onSaveProp);
 
 	const onLinkChange = (value: string, i: number) => {
-		const links = item.links;
+		const links = propItem.links;
 		links[i] = value;
-		changePropertyItem(item, "links", links);
+		changePropertyItem(propItem, "links", links);
 	}
 
 	const onAddLink = () => {
-		const links = item.links.slice();
+		const links = propItem.links.slice();
 		links.push("new link");
-		changePropertyItem(item, "links", links);
+		changePropertyItem(propItem, "links", links);
 	}
 
 	const onDeleteLink = (i: number) => {
-		const links = item.links.slice();
+		const links = propItem.links.slice();
 		links.splice(i, 1);
-		changePropertyItem(item, "links", links);
+		changePropertyItem(propItem, "links", links);
 	}
 
 	const onDateChange = (start: Date, end?: Date) => {
-		const newItem = changePropertyItem(item, "date", start);
+		const newItem = changePropertyItem(propItem, "date", start);
+		end && changePropertyItem(newItem, "endDate", end);
 		end && changePropertyItem(newItem, "endDate", end);
 	}
 
 	const onDateRemove = () => {
-		const newItem = changePropertyItem(item, "date", null);
+		const newItem = changePropertyItem(propItem, "date", null);
 		changePropertyItem(newItem, "endDate", null);
 	}
-
-	const onCancel = () => {
-		console.log(propItem);
-		setItem(propItem);
-		setIsDirty(false);
-		disabled && cancelDisabled(propItem.id);
-	}
-
-	const onSave = () => {
-		setIsDirty(false);
-		onSaveProp(item);
-	}
 	return <>
-		<Panel className="my-1" disabled={disabled}>
-			<Input include={Label} label="Text" type="textarea" value={item.text} inputClass="w-full" onChange={value => changePropertyItem(item, "text", value)}/>
+		<Panel className="my-1">
+			<Input include={Label} label="Text" type="textarea" value={propItem.text} inputClass="w-full" onChange={value => changePropertyItem(propItem, "text", value)}/>
 			<Label label="Date" className="inline-block my-1 mr-1">
-				<RemoveField onRemove={onDateRemove} value={!!item.date}>
-					<DateRangePicker start={item.date} end={item.endDate || item.date} onChange={onDateChange} />
+				<RemoveField onRemove={onDateRemove} value={!!propItem.date}>
+					<DateRangePicker start={propItem.date} end={propItem.endDate || propItem.date} onChange={onDateChange} />
 				</RemoveField>
 			</Label>
-			<Input include={Label} label="Subcategory" className="my-1" value={item.subcategory || ''} inputClass="w-full" onChange={value => changePropertyItem(item, "subcategory", value || null)}/>
+			<Input include={Label} label="Subcategory" className="my-1" value={propItem.subcategory || ''} inputClass="w-full" onChange={value => changePropertyItem(propItem, "subcategory", value || null)}/>
 			<Label label="Links" className="my-1">
-				<AddRemove items={item.links.map((link, i) => <Input key={i} value={link} inputClass="w-full" onChange={(value: string) => onLinkChange(value, i)}/>)}
+				<AddRemove items={propItem.links.map((link, i) => ({component: Input, props: {value:link, inputClass: "w-full", onChange: (value: string) => onLinkChange(value, i)}}))}
 					onAdd={onAddLink} onDelete={onDeleteLink}/>
 			</Label>
-			{!isNew && (isDirty || disabled) && <div className="my-1 text-right mx-4 z-20 relative">
-				{item.id > 0 && <Button className="mx-1" mode="secondary" onClick={onCancel}>Cancel</Button>}
-				<Button mode="primary" onClick={onSave}>Save</Button>
-			</div>}
 		</Panel>
 	</>
 }

--- a/src/utils/components/edit/edit-timeline-items.tsx
+++ b/src/utils/components/edit/edit-timeline-items.tsx
@@ -142,7 +142,7 @@ export const EditTimelineItems = () => {
 							<ColorPicker value={category.color} onChange={(color) => changeProperty(category, 'color', color)}/>
 						</Label>
 					</div>
-					<AddRemoveEditable items={category.items.map((item, i) => ({component: EditRestorationItem, props: {
+					<AddRemoveEditable items={category.items.map((item, i) => ({component: EditRestorationItem, id: item.id.toString(), props: {
 							data: item, 
 							onEdit: (item: RestorationTimelineItem) => saveItem(item, i),
 							onDelete: () => onItemDelete(i)
@@ -189,7 +189,7 @@ const EditRestorationItem = ({data: propItem, onEdit: onSaveProp}: EditRestorati
 		changePropertyItem(newItem, "endDate", null);
 	}
 	return <>
-		<Panel className="my-1">
+		<Panel className="my-1" role="editable-timeline-item">
 			<Input include={Label} label="Text" type="textarea" value={propItem.text} inputClass="w-full" onChange={value => changePropertyItem(propItem, "text", value)}/>
 			<Label label="Date" className="inline-block my-1 mr-1">
 				<RemoveField onRemove={onDateRemove} value={!!propItem.date}>
@@ -198,7 +198,7 @@ const EditRestorationItem = ({data: propItem, onEdit: onSaveProp}: EditRestorati
 			</Label>
 			<Input include={Label} label="Subcategory" className="my-1" value={propItem.subcategory || ''} inputClass="w-full" onChange={value => changePropertyItem(propItem, "subcategory", value || null)}/>
 			<Label label="Links" className="my-1">
-				<AddRemove items={propItem.links.map((link, i) => ({component: Input, props: {value:link, inputClass: "w-full", onChange: (value: string) => onLinkChange(value, i)}}))}
+				<AddRemove items={propItem.links.map((link, i) => ({id: link, component: Input, props: {value:link, inputClass: "w-full", onChange: (value: string) => onLinkChange(value, i)}}))}
 					onAdd={onAddLink} onDelete={onDeleteLink}/>
 			</Label>
 		</Panel>

--- a/src/utils/components/edit/editable.tsx
+++ b/src/utils/components/edit/editable.tsx
@@ -37,7 +37,7 @@ function Editable<T extends React.ElementType>({children, as, icons, editable = 
 		<div className="hover:bg-sky-200/50 p-2 rounded-md peer">
 			{render}
 		</div>
-		<div className="transition-all peer-focus:opacity-100 peer-hover:opacity-100 opacity-0 invisible peer-focus:visible peer-hover:visible hover:visible hover:opacity-100 absolute -top-8 ">
+		<div className="transition-all peer-focus:opacity-100 peer-hover:opacity-100 opacity-0 invisible peer-focus:visible peer-hover:visible hover:visible hover:opacity-100 absolute -top-8 z-20">
 			{icons?.map((icon, i) => {
 				if ("icon" in icon) {
 					const Icon = icon.icon;

--- a/src/utils/components/edit/editable.tsx
+++ b/src/utils/components/edit/editable.tsx
@@ -13,8 +13,11 @@ type TextProps<C extends React.ElementType> = PolymorphicComponentProps<
   EditableProps
 >
 
-export interface EditableComponentProps<T> {
-	onDelete: () => void,
+export interface DeletableComponentProps {
+	onDelete: () => void
+}
+
+export interface EditableComponentProps<T> extends DeletableComponentProps {
 	onEdit: (data: T) => void,
 	data: T 
 }

--- a/src/utils/components/edit/editable.tsx
+++ b/src/utils/components/edit/editable.tsx
@@ -13,15 +13,24 @@ type TextProps<C extends React.ElementType> = PolymorphicComponentProps<
   EditableProps
 >
 
+export interface EditableComponentProps<T> {
+	onDelete: () => void,
+	onEdit: (data: T) => void,
+	data: T | null
+}
+
+export type EditableComponent<T> = React.ComponentType<EditableComponentProps<T>>
+
 export type ButtonIcon = {
 	icon: IconComponent,
 	handler: () => void,
 } | JSX.Element
 
+export type ContentEditableComponent = {contentEditable?: boolean | "true" | "false" };
+
 function Editable<T extends React.ElementType>({children, as, icons, editable = 'true', wrapped = false, ...rest}: TextProps<T>) {
 	const Component = as || 'span';
 	
-	//const classAll: string = 'hover:bg-sky-200/50 p-2 rounded-md peer ' + (className || '');
 	const render = wrapped ? children : <Component {...rest} contentEditable={editable}>{children}</Component>
 	return <div className="relative"> 
 		
@@ -46,8 +55,5 @@ function Editable<T extends React.ElementType>({children, as, icons, editable = 
 		</div>
 	</div>
 }
-
-export type ContentEditableComponent = {contentEditable?: boolean | "true" | "false" };
-
 
 export default Editable;

--- a/src/utils/components/edit/editable.tsx
+++ b/src/utils/components/edit/editable.tsx
@@ -16,7 +16,7 @@ type TextProps<C extends React.ElementType> = PolymorphicComponentProps<
 export interface EditableComponentProps<T> {
 	onDelete: () => void,
 	onEdit: (data: T) => void,
-	data: T | null
+	data: T 
 }
 
 export type EditableComponent<T> = React.ComponentType<EditableComponentProps<T>>

--- a/src/utils/services/EventPageService.ts
+++ b/src/utils/services/EventPageService.ts
@@ -21,6 +21,18 @@ export const useEventPagesMutation = () => {
 	};
 }
 
+export const useComponentSettingsMutation = () => {
+	const createMutation = api.page.createSetting.useMutation();
+	const updateMutation = api.page.updateSetting.useMutation();
+	const deleteMutation = api.page.deleteSetting.useMutation();
+
+	return {
+		create: createMutation, 
+		update: updateMutation, 
+		deletem: deleteMutation
+	};
+}
+
 type GetPageUrl = {
 	data: undefined,
 	isLoading: true,


### PR DESCRIPTION
Before when you update a component on a page, it would delete the whole page and then add a new one. But this of course is not ideal, so now there is functionality to make each of the components "dirty" and update individual like how the edit timeline items works.